### PR TITLE
Add Animation::set_current_tag_frame

### DIFF
--- a/src/anim.rs
+++ b/src/anim.rs
@@ -161,6 +161,15 @@ impl AsepriteAnimation {
         })
     }
 
+    /// Set current frame relative index within the current tag
+    pub fn set_current_tag_frame(&mut self, info: &AsepriteInfo, frame: usize) {
+        let Some(tag) = self.tag.as_ref().and_then(|tag| info.tags.get(tag)) else {
+            return;
+        };
+
+        self.current_frame = (tag.frames.start as usize + frame).max(tag.frames.end as usize - 1);
+    }
+
     /// The number of remaning frames in the current tag
     pub fn remaining_tag_frames(&self, info: &AsepriteInfo) -> Option<usize> {
         self.tag.as_ref().and_then(|tag| {


### PR DESCRIPTION
Hello! This is just a suggestion. Feel free to modify, use a different approach, or close the PR.

**Proposal**

It can be useful to be able to start at a frame that's not the initial tag frame. `set_current_tag_frame()` with a frame relative to the tag start frame can solve this.

**Use case**

You have a 8 directional character animation with 10 frames each. You would like when transitioning between e.g. North to North East movement to continue the animation at the step it was left of in the North animation.

This can now be done as:
```
let previous_frame_index = animation.current_tag_frame(info);
*animation = AsepriteAnimation::new(info, "North East");
animation.set_current_tag_frame(info, previous_frame_index);
```

Arguably, you should be able to create the animation while also specifying the tag. So maybe separately also add something like:
```
AsepriteAnimation::new_at_index(info, "North East", previous_frame_index)
```